### PR TITLE
Fix OAuth proxy redirect handling (resolves #17, #20)

### DIFF
--- a/netlify/edge-functions/oauth-oura-proxy.js
+++ b/netlify/edge-functions/oauth-oura-proxy.js
@@ -25,6 +25,15 @@ export default async (request, context) => {
     }
 
     const response = await fetch(targetUrl, init);
+    
+    // Handle redirects properly
+    if (response.status === 301 || response.status === 302 || response.status === 303 || response.status === 307 || response.status === 308) {
+      const location = response.headers.get('Location');
+      if (location) {
+        return Response.redirect(location, response.status);
+      }
+    }
+    
     const bodyText = await response.text();
     const contentType = response.headers.get('Content-Type') || 'text/html; charset=UTF-8';
 

--- a/netlify/edge-functions/oauth-strava-proxy.js
+++ b/netlify/edge-functions/oauth-strava-proxy.js
@@ -25,6 +25,15 @@ export default async (request, context) => {
     }
 
     const response = await fetch(targetUrl, init);
+    
+    // Handle redirects properly
+    if (response.status === 301 || response.status === 302 || response.status === 303 || response.status === 307 || response.status === 308) {
+      const location = response.headers.get('Location');
+      if (location) {
+        return Response.redirect(location, response.status);
+      }
+    }
+    
     const bodyText = await response.text();
     const contentType = response.headers.get('Content-Type') || 'text/html; charset=UTF-8';
 

--- a/scripts/test-oauth.sh
+++ b/scripts/test-oauth.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Test OAuth endpoints
+
+echo "Testing OAuth endpoints..."
+echo
+
+# Test Oura OAuth start
+echo "Testing Oura OAuth start..."
+curl -I "https://fitlinkbot.netlify.app/oauth-oura/start?user_id=TEST123"
+echo
+
+# Test Strava OAuth start  
+echo "Testing Strava OAuth start..."
+curl -I "https://fitlinkbot.netlify.app/oauth-strava/start?user_id=TEST123"
+echo
+
+echo "If you see 302 redirects above, the OAuth proxies are working correctly."
+echo "The Location header should point to the OAuth provider's authorization page."


### PR DESCRIPTION
## Summary
- Fixes Netlify Edge Function crashes when accessing OAuth start endpoints
- Properly handles redirect responses (301/302/303/307/308) from Supabase functions
- Adds test script to verify OAuth endpoints work correctly

## Problem
The Netlify OAuth proxies were using `redirect: 'manual'` but not properly handling redirect responses. When the Supabase OAuth functions returned redirects to provider authorization pages (Oura/Strava), the proxy would try to read the body instead of passing through the redirect, causing crashes.

## Solution
Added redirect detection in both `oauth-oura-proxy.js` and `oauth-strava-proxy.js` to:
1. Check if response status is a redirect (301-308)
2. Extract the Location header
3. Return a proper `Response.redirect()` to the browser

## Test plan
- [ ] Deploy to Netlify
- [ ] Run `./scripts/test-oauth.sh` to verify 302 redirects are returned
- [ ] Test full OAuth flow: `/connect_oura` and `/connect_strava` commands
- [ ] Verify successful authorization and token storage

Fixes #17, Fixes #20

🤖 Generated with [Claude Code](https://claude.ai/code)